### PR TITLE
Fix argument passing to Meteor.Collection.update.

### DIFF
--- a/collection-hooks.js
+++ b/collection-hooks.js
@@ -57,11 +57,28 @@
 	};
 
 	Meteor.Collection.prototype.update = function (selector, modifier, options, callback) {
-		var result, previous, userId = getUserId.call(this);
+    var result,
+      previous,
+      updateArgumentsRaw = [selector, modifier, options, callback].reverse(),
+      updateArguments = [],
+      userId = getUserId.call(this);
 
 		if (delegate.call(this, "before", "update", userId, selector, modifier, options, callback) !== false) {
 			previous = this._collection.find(selector, {reactive: false}).fetch();
-			result = directUpdate.call(this, selector, modifier, options, callback);
+
+      // Build an array of the parameters in preparation for Function.apply. We can't use call here because of the way Meteor.Collection.update resolves if the last parameter is a callback or not. If we use call, and the caller didn't pass options, callbacks won't work. We need to trim any undefined arguments off the end of the arguments array that we pass.
+      var stopFiltering = false;
+      for (var ua in updateArgumentsRaw) {
+        // Skip undefined values until we hit a non-undefined value. Then accept everything.
+        if (stopFiltering || updateArgumentsRaw[ua] !== undefined) {
+          updateArguments.push(updateArgumentsRaw[ua]);
+          stopFiltering = true;
+        }
+      }
+
+      updateArguments = updateArguments.reverse();
+
+      result = directUpdate.apply(this, updateArguments);
 			delegate.call(this, "after", "update", userId, selector, modifier, options, previous, callback);
 		}
 


### PR DESCRIPTION
This only affects the overridden `Meteor.Collection.update`; no fixes are needed for insert or remove. This is because `insert` and `remove` only take 1 or 2 arguments, and passing a `callback` to them without a `selector` wouldn't make any sense anyway. However, not passing `options` to `update` (and terminating the invocation with a callback) is rather common.
