### PR TITLE
Add back options parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ test.before.insert(function (userId, doc) {
 
 --------------------------------------------------------------------------------
 
-### .before.update(userId, doc, fieldNames, modifier)
+### .before.update(userId, doc, fieldNames, modifier, options)
 
 Fired before the doc is updated.
 
@@ -39,7 +39,7 @@ ultimately gets sent down to the real `update` method.
 defined.
 
 ```javascript
-test.before.update(function (userId, doc, fieldNames, modifier) {
+test.before.update(function (userId, doc, fieldNames, modifier, options) {
   modifier.$set.modifiedAt = Date.now();
 });
 ```
@@ -82,7 +82,7 @@ test.after.insert(function (userId, doc) {
 
 --------------------------------------------------------------------------------
 
-### .after.update(userId, doc, fieldNames, modifier)
+### .after.update(userId, doc, fieldNames, modifier, options)
 
 Fired after the doc was updated.
 
@@ -94,7 +94,7 @@ previous and new documents to take further action.
 defined.
 
 ```javascript
-test.after.update(function (userId, doc, fieldNames, modifier) {
+test.after.update(function (userId, doc, fieldNames, modifier, options) {
   // ...
 });
 ```

--- a/update.js
+++ b/update.js
@@ -23,6 +23,7 @@ CollectionHooks.defineAdvice("update", function (userId, _super, aspects, getTra
   // copy originals for convenience for the "after" pointcut
   if (aspects.after) {
     prev.mutator = EJSON.clone(args[1]);
+    prev.options = EJSON.clone(args[2]);
     prev.docs = {};
     _.each(docs, function (doc) {
       prev.docs[doc._id] = EJSON.clone(doc);
@@ -32,7 +33,7 @@ CollectionHooks.defineAdvice("update", function (userId, _super, aspects, getTra
   // before
   _.each(aspects.before, function (aspect) {
     _.each(docs, function (doc) {
-      aspect.call(_.extend({transform: getTransform(doc)}, ctx), userId, doc, fields, args[1]);
+      aspect.call(_.extend({transform: getTransform(doc)}, ctx), userId, doc, fields, args[1], args[2]);
     });
   });
 
@@ -45,7 +46,7 @@ CollectionHooks.defineAdvice("update", function (userId, _super, aspects, getTra
         aspect.call(_.extend({
           transform: getTransform(doc),
           previous: prev.docs[doc._id]
-        }, ctx), userId, doc, fields, prev.mutator);
+        }, ctx), userId, doc, fields, prev.mutator, prev.options);
       });
     });
   }


### PR DESCRIPTION
This is mostly to enable workarounds when implementers need to avoid recursion.
