### PR TITLE
assume insert callback is last arg instead of second

### DIFF
--- a/insert.js
+++ b/insert.js
@@ -30,10 +30,11 @@ CollectionHooks.defineAdvice("insert", function (userId, _super, aspects, getTra
   }
 
   if (async) {
-    return _super.call(self, args[0], function (err, obj) {
+    args[args.length - 1] = function (err, obj) {
       after(obj && obj[0] && obj[0]._id || obj, err);
       return callback.apply(this, arguments);
-    });
+    };
+    return _super.apply(self, args);
   } else {
     ret = _super.apply(self, args);
     return after(ret && ret[0] && ret[0]._id || ret);

--- a/remove.js
+++ b/remove.js
@@ -1,7 +1,8 @@
 CollectionHooks.defineAdvice("remove", function (userId, _super, aspects, getTransform, args) {
   var self = this;
   var ctx = {context: self, _super: _super, args: args};
-  var async = _.isFunction(_.last(args));
+  var callback = _.last(args); // more future proof to use last vs. args[1]
+  var async = _.isFunction(callback);
   var docs, abort, prev = [];
   var collection = _.has(self, "_collection") ? self._collection : self;
 
@@ -36,10 +37,11 @@ CollectionHooks.defineAdvice("remove", function (userId, _super, aspects, getTra
   }
 
   if (async) {
-    return _super.call(self, args[0], function (err) {
+    args[args.length - 1] = function (err) {
       after(err);
-      return args[1].apply(this, arguments);
-    });
+      return callback.apply(this, arguments);
+    };
+    return _super.apply(self, args);
   } else {
     var result = _super.apply(self, args);
     after();


### PR DESCRIPTION
This tiny change fixes an issue I'm having with my package, collection2. C2 overrides Meteor.Collection in a similar way to collection-hooks, but it adds support for `options` as the second argument of `insert`. It removes the options argument before passing to the real `insert`. However, it seems that Meteor always loads collection-hooks after collection2, which means that the collection-hooks `insert` method is run first, and it is confused by `args[1]` not being a function.

This simple change uses the last argument instead of the second argument, which is more future-proof coding anyway.

aldeed/meteor-collection2#50
