### PR TITLE
ensure $set is not undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ defined.
 
 ```javascript
 test.before.update(function (userId, doc, fieldNames, modifier, options) {
+  modifier.$set = modifier.$set || {};
   modifier.$set.modifiedAt = Date.now();
 });
 ```


### PR DESCRIPTION
if i have a hook like so:

```
Things.before.update(function (userId, doc, fieldNames, modifier, options) {
    modifier.$set.updatedAt = new Date();
});
```

an update like this works without checking/initing $set

```
Things.update({_id:"wAARchoDwYubfff2J"},{$set:{name:"updated"}});
```

but this does not

```
Things.update({_id:"wAARchoDwYubfff2J"},{$inc:{count:1}});
```

if $set is not used in the update, then it has to be initialized before it can be added to or altered
## 

noted by AVITAL OLIVER during a review of this article - https://meteor.hackpad.com/Meteor-Cookbook-Using-Dates-and-Times-qSQCGFc06gH
