### PR TITLE
Make it possible to replace cursor/doc in after find/findOne

### DIFF
--- a/find.js
+++ b/find.js
@@ -15,6 +15,7 @@ CollectionHooks.defineAdvice("find", function (userId, _super, instance, aspects
   if (abort) return false;
 
   function after(cursor) {
+    _.extend(ctx, {cursor: cursor});
     _.each(aspects.after, function (o) {
       o.aspect.call(ctx, userId, args[0], args[1], cursor);
     });
@@ -23,5 +24,5 @@ CollectionHooks.defineAdvice("find", function (userId, _super, instance, aspects
   ret = _super.apply(self, args);
   after(ret);
 
-  return ret;
+  return ctx.cursor;
 });

--- a/findone.js
+++ b/findone.js
@@ -15,6 +15,7 @@ CollectionHooks.defineAdvice("findOne", function (userId, _super, instance, aspe
   if (abort) return false;
 
   function after(doc) {
+    _.extend(ctx, {doc: doc});
     _.each(aspects.after, function (o) {
       o.aspect.call(ctx, userId, args[0], args[1], doc);
     });
@@ -23,5 +24,5 @@ CollectionHooks.defineAdvice("findOne", function (userId, _super, instance, aspe
   ret = _super.apply(self, args);
   after(ret);
 
-  return ret;
+  return ctx.doc;
 });


### PR DESCRIPTION
Should resolve #63 as you can use this.cursor/this.doc to replace the cursor/doc in after hooks