### PR TITLE
Re-assign prototype constructor too

### DIFF
--- a/collection-hooks.js
+++ b/collection-hooks.js
@@ -193,6 +193,7 @@ CollectionHooks.wrapCollection = function (ns, as) {
   };
 
   ns.Collection.prototype = proto;
+  ns.Collection.prototype.constructor = ns.Collection;
 
   for (var prop in constructor) {
     if (constructor.hasOwnProperty(prop)) {


### PR DESCRIPTION
This fixes an issue, mostly for Coffeescript users, where if you try creating a sub-class of `Mongo.Collection`, the constructor of the subclass will not be able to inherit from the wrapped constructor.